### PR TITLE
투두 리스트 CRUD 기능 및 회원 탈퇴 기능 구현

### DIFF
--- a/src/app/api/jds/[jdId]/alarm/route.ts
+++ b/src/app/api/jds/[jdId]/alarm/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ jdId: string }> }
+) {
+  try {
+    const { jdId } = await params;
+    
+    // Authorization 헤더에서 토큰 추출
+    const authHeader = request.headers.get('authorization');
+    const accessToken = authHeader?.replace('Bearer ', '');
+    
+    if (!accessToken) {
+      return NextResponse.json(
+        { code: 401, message: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    // 요청 본문 파싱
+    const requestBody = await request.json();
+
+    // 백엔드 서버로 알림 토글 요청
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || 'https://api.jogakjogak.com'}/jds/${jdId}/alarm`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { code: response.status, message: data.message || 'Failed to toggle alarm' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Alarm toggle error:', error);
+    return NextResponse.json(
+      { code: 500, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/jds/[jdId]/bookmark/route.ts
+++ b/src/app/api/jds/[jdId]/bookmark/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ jdId: string }> }
+) {
+  try {
+    const { jdId } = await params;
+    
+    // Authorization 헤더에서 토큰 추출
+    const authHeader = request.headers.get('authorization');
+    const accessToken = authHeader?.replace('Bearer ', '');
+    
+    if (!accessToken) {
+      return NextResponse.json(
+        { code: 401, message: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    // 요청 본문 파싱
+    const requestBody = await request.json();
+
+    // 백엔드 서버로 북마크 토글 요청
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || 'https://api.jogakjogak.com'}/jds/${jdId}/bookmark`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { code: response.status, message: data.message || 'Failed to toggle bookmark' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Bookmark toggle error:', error);
+    return NextResponse.json(
+      { code: 500, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/jds/[jdId]/memo/route.ts
+++ b/src/app/api/jds/[jdId]/memo/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ jdId: string }> }
+) {
+  try {
+    const { jdId } = await params;
+    
+    // Authorization 헤더에서 토큰 추출
+    const authHeader = request.headers.get('authorization');
+    const accessToken = authHeader?.replace('Bearer ', '');
+    
+    if (!accessToken) {
+      return NextResponse.json(
+        { code: 401, message: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const { memo } = body;
+
+    // 백엔드 서버로 메모 수정 요청
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || 'https://api.jogakjogak.com'}/jds/${jdId}/memo`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ memo }),
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { code: response.status, message: data.message || 'Failed to update memo' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Memo update error:', error);
+    return NextResponse.json(
+      { code: 500, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/jds/[jdId]/route.ts
+++ b/src/app/api/jds/[jdId]/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ jdId: string }> }
+) {
+  try {
+    const { jdId } = await params;
+    
+    // Authorization 헤더에서 토큰 추출
+    const authHeader = request.headers.get('authorization');
+    const accessToken = authHeader?.replace('Bearer ', '');
+    
+    if (!accessToken) {
+      return NextResponse.json(
+        { code: 401, message: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    // 백엔드 서버로 JD 상세 조회 요청
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || 'https://api.jogakjogak.com'}/jds/${jdId}`,
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { code: response.status, message: data.message || 'Failed to fetch JD' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('JD fetch error:', error);
+    return NextResponse.json(
+      { code: 500, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ jdId: string }> }
+) {
+  try {
+    const { jdId } = await params;
+    
+    // Authorization 헤더에서 토큰 추출
+    const authHeader = request.headers.get('authorization');
+    const accessToken = authHeader?.replace('Bearer ', '');
+    
+    if (!accessToken) {
+      return NextResponse.json(
+        { code: 401, message: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    // 백엔드 서버로 JD 삭제 요청
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || 'https://api.jogakjogak.com'}/jds/${jdId}`,
+      {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+        },
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { code: response.status, message: data.message || 'Failed to delete JD' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('JD delete error:', error);
+    return NextResponse.json(
+      { code: 500, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/jds/[jdId]/to-do-lists/[todoId]/route.ts
+++ b/src/app/api/jds/[jdId]/to-do-lists/[todoId]/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ jdId: string; todoId: string }> }
+) {
+  try {
+    const { jdId, todoId } = await params;
+    
+    // Authorization 헤더에서 토큰 추출
+    const authHeader = request.headers.get('authorization');
+    const accessToken = authHeader?.replace('Bearer ', '');
+    
+    if (!accessToken) {
+      return NextResponse.json(
+        { code: 401, message: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    // 요청 본문 파싱
+    const requestBody = await request.json();
+
+    // 백엔드 서버로 Todo 업데이트 요청
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || 'https://api.jogakjogak.com'}/jds/${jdId}/to-do-lists/${todoId}`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { code: response.status, message: data.message || 'Failed to update todo' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Todo update error:', error);
+    return NextResponse.json(
+      { code: 500, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ jdId: string; todoId: string }> }
+) {
+  try {
+    const { jdId, todoId } = await params;
+    
+    // Authorization 헤더에서 토큰 추출
+    const authHeader = request.headers.get('authorization');
+    const accessToken = authHeader?.replace('Bearer ', '');
+    
+    if (!accessToken) {
+      return NextResponse.json(
+        { code: 401, message: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    // 백엔드 서버로 Todo 삭제 요청
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || 'https://api.jogakjogak.com'}/jds/${jdId}/to-do-lists/${todoId}`,
+      {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const data = await response.json();
+      return NextResponse.json(
+        { code: response.status, message: data.message || 'Failed to delete todo' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json({ message: 'Todo deleted successfully' });
+  } catch (error) {
+    console.error('Todo delete error:', error);
+    return NextResponse.json(
+      { code: 500, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/jds/[jdId]/to-do-lists/route.ts
+++ b/src/app/api/jds/[jdId]/to-do-lists/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ jdId: string }> }
+) {
+  try {
+    const { jdId } = await params;
+    
+    // Authorization 헤더에서 토큰 추출
+    const authHeader = request.headers.get('authorization');
+    const accessToken = authHeader?.replace('Bearer ', '');
+    
+    if (!accessToken) {
+      return NextResponse.json(
+        { code: 401, message: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    // 요청 본문 파싱
+    const requestBody = await request.json();
+
+    // 백엔드 서버로 Todo 생성 요청
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || 'https://api.jogakjogak.com'}/jds/${jdId}/to-do-lists`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { code: response.status, message: data.message || 'Failed to create todo' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Todo create error:', error);
+    return NextResponse.json(
+      { code: 500, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/jds/create/route.ts
+++ b/src/app/api/jds/create/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    // Authorization 헤더에서 토큰 추출
+    const authHeader = request.headers.get('authorization');
+    const accessToken = authHeader?.replace('Bearer ', '');
+    
+    if (!accessToken) {
+      return NextResponse.json(
+        { code: 401, message: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const { title, companyName, job, content, link, endDate } = body;
+
+    // 필수 필드 검증
+    if (!title || !companyName || !job || !content || !endDate) {
+      return NextResponse.json(
+        { 
+          code: 400, 
+          message: 'Missing required fields: title, companyName, job, content, endDate are required' 
+        },
+        { status: 400 }
+      );
+    }
+
+    // 백엔드 서버로 채용공고 생성 요청
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || 'https://api.jogakjogak.com'}/jds`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title,
+          companyName,
+          job,
+          content,
+          jdUrl: link || "",  // link → jdUrl, 빈 문자열 기본값
+          endedAt: `${endDate}T23:59:59`  // DateTime 형식으로 변환
+        }),
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      // 백엔드 에러 형식에 맞춰 처리
+      const errorMessage = data.message || data.errorMessage || 'Failed to create JD';
+      
+      return NextResponse.json(
+        { 
+          code: response.status, 
+          message: errorMessage,
+          errorCode: data.errorCode
+        },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data, { status: 201 });
+  } catch (error) {
+    console.error('JD creation error:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json(
+      { 
+        code: 500, 
+        message: `Internal server error: ${errorMessage}`,
+        details: error instanceof Error ? error.stack : undefined
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/jds/route.ts
+++ b/src/app/api/jds/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  try {
+    // Authorization 헤더에서 토큰 추출
+    const authHeader = request.headers.get('authorization');
+    const accessToken = authHeader?.replace('Bearer ', '');
+    
+    if (!accessToken) {
+      return NextResponse.json(
+        { code: 401, message: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    // 쿼리 파라미터 추출
+    const searchParams = request.nextUrl.searchParams;
+    const page = searchParams.get('page') || '0';
+    const size = searchParams.get('size') || '11';
+    const sort = searchParams.get('sort') || 'createdAt';
+    const direction = searchParams.get('direction') || 'DESC';
+
+    const queryString = new URLSearchParams({
+      page,
+      size,
+      sort,
+      direction
+    }).toString();
+
+    // 백엔드 서버로 요청
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || 'https://api.jogakjogak.com'}/jds?${queryString}`,
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { code: response.status, message: data.message || 'Failed to fetch jds' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('JDs fetch error:', error);
+    return NextResponse.json(
+      { code: 500, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/member/logout/route.ts
+++ b/src/app/api/member/logout/route.ts
@@ -2,14 +2,26 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { refresh_token } = body;
+    let refresh_token;
+    
+    // Content-Type과 body 존재 여부 확인
+    const contentType = request.headers.get('content-type');
+    if (contentType?.includes('application/json')) {
+      try {
+        const body = await request.json();
+        refresh_token = body.refresh_token;
+      } catch {
+        // JSON 파싱 실패 시 refresh_token 없음으로 처리
+      }
+    }
 
     if (!refresh_token) {
-      return NextResponse.json(
-        { code: 400, message: 'refresh_token is required' },
-        { status: 400 }
+      // refresh_token이 없어도 쿠키는 삭제하고 성공 응답
+      const res = NextResponse.json(
+        { code: 200, message: 'Logged out successfully (no token)' }
       );
+      res.cookies.delete('refresh');
+      return res;
     }
 
     // 백엔드 서버로 로그아웃 요청

--- a/src/app/api/member/withdrawal/route.ts
+++ b/src/app/api/member/withdrawal/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function DELETE(request: NextRequest) {
+  try {
+    // Authorization 헤더에서 토큰 추출
+    const authHeader = request.headers.get('authorization');
+    const accessToken = authHeader?.replace('Bearer ', '');
+    
+    if (!accessToken) {
+      return NextResponse.json(
+        { code: 401, message: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    // 백엔드 서버로 회원 탈퇴 요청
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || 'https://api.jogakjogak.com'}/member/withdrawal`,
+      {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const data = await response.json();
+      return NextResponse.json(
+        { code: response.status, message: data.message || 'Failed to withdraw member' },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Member withdrawal error:', error);
+    return NextResponse.json(
+      { code: 500, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/resume/[resumeId]/route.ts
+++ b/src/app/api/resume/[resumeId]/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ resumeId: string }> }
+) {
+  try {
+    const { resumeId } = await params;
+    
+    // Authorization 헤더에서 토큰 추출
+    const authHeader = request.headers.get('authorization');
+    const accessToken = authHeader?.replace('Bearer ', '');
+    
+    if (!accessToken) {
+      return NextResponse.json(
+        { code: 401, message: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    // 백엔드 서버로 이력서 조회 요청
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || 'https://api.jogakjogak.com'}/resume/${resumeId}`,
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { code: response.status, message: data.message || 'Failed to fetch resume' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Resume fetch error:', error);
+    return NextResponse.json(
+      { code: 500, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ resumeId: string }> }
+) {
+  try {
+    const { resumeId } = await params;
+    
+    // Authorization 헤더에서 토큰 추출
+    const authHeader = request.headers.get('authorization');
+    const accessToken = authHeader?.replace('Bearer ', '');
+    
+    if (!accessToken) {
+      return NextResponse.json(
+        { code: 401, message: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const { title, content } = body;
+
+    // 유효성 검사
+    if (!title || !content) {
+      return NextResponse.json(
+        { code: 400, message: 'Title and content are required' },
+        { status: 400 }
+      );
+    }
+
+    if (title.length > 30) {
+      return NextResponse.json(
+        { code: 400, message: 'Title must be 30 characters or less' },
+        { status: 400 }
+      );
+    }
+
+    if (content.length > 5000) {
+      return NextResponse.json(
+        { code: 400, message: 'Content must be 5000 characters or less' },
+        { status: 400 }
+      );
+    }
+
+    // 백엔드 서버로 이력서 수정 요청
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || 'https://api.jogakjogak.com'}/resume/${resumeId}`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ title, content }),
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { code: response.status, message: data.message || 'Failed to update resume' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Resume update error:', error);
+    return NextResponse.json(
+      { code: 500, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/resume/route.ts
+++ b/src/app/api/resume/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    // Authorization 헤더에서 토큰 추출
+    const authHeader = request.headers.get('authorization');
+    const accessToken = authHeader?.replace('Bearer ', '');
+    
+    if (!accessToken) {
+      return NextResponse.json(
+        { code: 401, message: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const { title, content } = body;
+
+    // 유효성 검사
+    if (!title || !content) {
+      return NextResponse.json(
+        { code: 400, message: 'Title and content are required' },
+        { status: 400 }
+      );
+    }
+
+    if (title.length > 30) {
+      return NextResponse.json(
+        { code: 400, message: 'Title must be 30 characters or less' },
+        { status: 400 }
+      );
+    }
+
+    if (content.length > 5000) {
+      return NextResponse.json(
+        { code: 400, message: 'Content must be 5000 characters or less' },
+        { status: 400 }
+      );
+    }
+
+    // 백엔드 서버로 이력서 생성 요청
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || 'https://api.jogakjogak.com'}/resume`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ title, content }),
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { code: response.status, message: data.message || 'Failed to create resume' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data, { status: 201 });
+  } catch (error) {
+    console.error('Resume creation error:', error);
+    return NextResponse.json(
+      { code: 500, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/job/[id]/page.module.css
+++ b/src/app/job/[id]/page.module.css
@@ -444,3 +444,134 @@
   width: 100%;
   max-width: 1260px;
 }
+
+/* Dropdown menu styles */
+.moreMenu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 8px;
+  background-color: #ffffff;
+  border: 1px solid var(--n-300);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+  min-width: 120px;
+  overflow: hidden;
+}
+
+.moreMenuItem {
+  display: block;
+  width: 100%;
+  padding: 12px 16px;
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--n-900);
+  font-family: var(--body-2-normal-medium-font-family);
+  font-size: var(--body-2-normal-medium-font-size);
+  font-weight: var(--body-2-normal-medium-font-weight);
+  transition: background-color 0.2s;
+}
+
+.moreMenuItem:hover {
+  background-color: var(--n-200);
+}
+
+.moreMenuItem:active {
+  background-color: var(--n-300);
+}
+
+/* Modal styles */
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.modal {
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 32px;
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+}
+
+.modalTitle {
+  font-family: var(--heading-2-bold-font-family);
+  font-size: var(--heading-2-bold-font-size);
+  font-weight: var(--heading-2-bold-font-weight);
+  color: var(--n-950);
+  margin: 0 0 16px 0;
+  text-align: center;
+}
+
+.modalMessage {
+  font-family: var(--body-1-normal-regular-font-family);
+  font-size: var(--body-1-normal-regular-font-size);
+  font-weight: var(--body-1-normal-regular-font-weight);
+  color: var(--n-700);
+  margin: 0 0 24px 0;
+  text-align: center;
+  line-height: 1.6;
+}
+
+.modalButtons {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.modalCancel,
+.modalConfirm {
+  padding: 12px 24px;
+  border-radius: 8px;
+  border: none;
+  font-family: var(--body-1-normal-bold-font-family);
+  font-size: var(--body-1-normal-bold-font-size);
+  font-weight: var(--body-1-normal-bold-font-weight);
+  cursor: pointer;
+  transition: all 0.2s;
+  min-width: 100px;
+}
+
+.modalCancel {
+  background-color: var(--n-200);
+  color: var(--n-700);
+}
+
+.modalCancel:hover {
+  background-color: var(--n-300);
+}
+
+.modalConfirm {
+  background-color: #ff4444;
+  color: #ffffff;
+}
+
+.modalConfirm:hover {
+  background-color: #ff3333;
+}
+
+/* Alarm button styles */
+.notificationBtn.alarmOn {
+  background-color: var(--primaryjogak-1);
+  border-color: var(--primaryjogak-1);
+}
+
+.notificationBtn.alarmOn:hover {
+  background-color: var(--primaryjogak-2);
+}
+
+.notificationBtn.alarmOn .notificationBtnText {
+  color: #ffffff;
+}

--- a/src/app/job/[id]/page.tsx
+++ b/src/app/job/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter, useParams } from "next/navigation";
 import Image from "next/image";
 import styles from "./page.module.css";
 import Header from "@/components/Header";
@@ -16,18 +16,544 @@ import bookmarkIcon from "@/assets/images/ic_add_to_bookmark.svg";
 import moreIcon from "@/assets/images/ic_more.svg";
 import contentEmphasisIcon from "@/assets/images/content-emphasis-and-reorganization.svg";
 import scheduleIcon from "@/assets/images/employment-schedule-and-others.svg";
+import { tokenManager } from "@/utils/auth";
+import { StaticImageData } from "next/image";
+
+interface TodoItem {
+  checklist_id: number;
+  category: string;
+  title: string;
+  content: string;
+  memo: string;
+  jdId: number;
+  createdAt: string;
+  updatedAt: string;
+  done: boolean;
+}
+
+interface JDDetail {
+  jd_id: number;
+  title: string;
+  bookmark: boolean;
+  companyName: string;
+  job: string;
+  content: string;
+  jdUrl: string;
+  memo: string;
+  memberId: number;
+  alarmOn: boolean;
+  applyAt: string | null;
+  endedAt: string;
+  createdAt: string;
+  updatedAt: string;
+  toDoLists: TodoItem[];
+}
+
+const CATEGORY_TITLES: { [key: string]: string } = {
+  'STRUCTURAL_COMPLEMENT_PLAN': '필요한 경험과 역량',
+  'CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL': '내용 강조 및 재구성',
+  'SCHEDULE_MISC_ERROR': '취업 일정 및 기타'
+};
+
+const CATEGORIES = [
+  { value: 'STRUCTURAL_COMPLEMENT_PLAN', label: '필요한 경험과 역량' },
+  { value: 'CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL', label: '내용 강조 및 재구성' },
+  { value: 'SCHEDULE_MISC_ERROR', label: '취업 일정 및 기타' }
+];
+
+const CATEGORY_COLORS: { [key: string]: string } = {
+  'STRUCTURAL_COMPLEMENT_PLAN': '#D9A9F9',
+  'CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL': '#FFD00E',
+  'SCHEDULE_MISC_ERROR': '#3DC3A9'
+};
+
+const CATEGORY_ICONS: { [key: string]: StaticImageData } = {
+  'CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL': contentEmphasisIcon,
+  'SCHEDULE_MISC_ERROR': scheduleIcon
+};
 
 export default function JobDetailPage() {
   const router = useRouter();
-  const [isBookmarked, setIsBookmarked] = useState(false);
+  const params = useParams();
+  const jdId = params.id as string;
+  
+  const [jdDetail, setJdDetail] = useState<JDDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [todosByCategory, setTodosByCategory] = useState<{ [key: string]: TodoItem[] }>({});
+  const [isSavingMemo, setIsSavingMemo] = useState(false);
+  const memoTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const [isTogglingAlarm, setIsTogglingAlarm] = useState(false);
+  const [showMoreMenu, setShowMoreMenu] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const moreMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const accessToken = tokenManager.getAccessToken();
+        const response = await fetch(`/api/jds/${jdId}`, {
+          headers: {
+            'Authorization': `Bearer ${accessToken}`
+          }
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+          if (data.data) {
+            setJdDetail(data.data);
+            
+            // 카테고리별로 투두 그룹화
+            const grouped = data.data.toDoLists.reduce((acc: { [key: string]: TodoItem[] }, todo: TodoItem) => {
+              if (!acc[todo.category]) acc[todo.category] = [];
+              acc[todo.category].push(todo);
+              return acc;
+            }, {});
+            setTodosByCategory(grouped);
+          }
+        }
+      } catch (error) {
+        console.error('Failed to fetch JD detail:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [jdId]);
+
 
   const handleBack = () => {
     router.back();
   };
 
-  const toggleBookmark = () => {
-    setIsBookmarked(!isBookmarked);
+  const toggleBookmark = async () => {
+    if (!jdDetail) return;
+    
+    // 즉시 UI 업데이트 (Optimistic update)
+    const newBookmarkState = !jdDetail.bookmark;
+    setJdDetail({ ...jdDetail, bookmark: newBookmarkState });
+    
+    try {
+      const accessToken = tokenManager.getAccessToken();
+      const response = await fetch(`/api/jds/${jdId}/bookmark`, {
+        method: 'PATCH',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          isBookmark: newBookmarkState
+        })
+      });
+
+      if (!response.ok) {
+        // 실패 시 원래 상태로 복원
+        setJdDetail({ ...jdDetail, bookmark: !newBookmarkState });
+        console.error('Failed to toggle bookmark');
+      } else {
+        const responseData = await response.json();
+        // 백엔드 응답에서 실제 상태로 업데이트
+        if (responseData.data) {
+          setJdDetail({ ...jdDetail, bookmark: responseData.data.bookmark });
+        }
+      }
+    } catch (error) {
+      // 에러 시 원래 상태로 복원
+      setJdDetail({ ...jdDetail, bookmark: !newBookmarkState });
+      console.error('Error toggling bookmark:', error);
+    }
   };
+
+  const calculateDDay = (endedAt: string) => {
+    const endDate = new Date(endedAt);
+    const today = new Date();
+    const diffTime = endDate.getTime() - today.getTime();
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    return diffDays > 0 ? diffDays : 0;
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const year = date.getFullYear().toString().slice(2);
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const weekDays = ['일', '월', '화', '수', '목', '금', '토'];
+    const weekDay = weekDays[date.getDay()];
+    return `${year}년 ${month}월 ${day}일 ${weekDay}요일`;
+  };
+
+  const formatTimeAgo = (dateString: string) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+    
+    if (diffInSeconds < 86400) {
+      return '오늘 수정';
+    } else {
+      const days = Math.floor(diffInSeconds / 86400);
+      return `${days}일 전 수정`;
+    }
+  };
+
+  // 디바운스된 메모 저장 함수
+  const saveMemo = useCallback(async (memoText: string) => {
+    try {
+      setIsSavingMemo(true);
+      const accessToken = tokenManager.getAccessToken();
+      const response = await fetch(`/api/jds/${jdId}/memo`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${accessToken}`
+        },
+        body: JSON.stringify({ memo: memoText })
+      });
+
+      if (!response.ok) {
+        console.error('Failed to save memo');
+      }
+    } catch (error) {
+      console.error('Error saving memo:', error);
+    } finally {
+      setIsSavingMemo(false);
+    }
+  }, [jdId]);
+
+  // 메모 변경 핸들러 (디바운스 적용)
+  const handleMemoChange = useCallback((value: string) => {
+    // 이전 타이머 취소
+    if (memoTimeoutRef.current) {
+      clearTimeout(memoTimeoutRef.current);
+    }
+
+    // 로컬 상태 즉시 업데이트
+    if (jdDetail) {
+      setJdDetail({ ...jdDetail, memo: value });
+    }
+
+    // 0.8초 후 저장
+    memoTimeoutRef.current = setTimeout(() => {
+      saveMemo(value);
+    }, 800);
+  }, [jdDetail, saveMemo]);
+
+  // 알림 토글 함수
+  const toggleAlarm = async () => {
+    if (!jdDetail || isTogglingAlarm) return;
+    
+    setIsTogglingAlarm(true);
+    const newAlarmState = !jdDetail.alarmOn;
+    setJdDetail({ ...jdDetail, alarmOn: newAlarmState });
+    
+    try {
+      const accessToken = tokenManager.getAccessToken();
+      const response = await fetch(`/api/jds/${jdId}/alarm`, {
+        method: 'PATCH',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          isAlarmOn: newAlarmState
+        })
+      });
+
+      if (!response.ok) {
+        // 실패 시 원래 상태로 복원
+        setJdDetail({ ...jdDetail, alarmOn: !newAlarmState });
+        console.error('Failed to toggle alarm');
+      } else {
+        const responseData = await response.json();
+        // 백엔드 응답에서 실제 상태로 업데이트
+        if (responseData.data) {
+          setJdDetail({ ...jdDetail, alarmOn: responseData.data.alarmOn });
+        }
+      }
+    } catch (error) {
+      // 에러 시 원래 상태로 복원
+      setJdDetail({ ...jdDetail, alarmOn: !newAlarmState });
+      console.error('Error toggling alarm:', error);
+    } finally {
+      setIsTogglingAlarm(false);
+    }
+  };
+
+  // 컴포넌트 언마운트 시 타이머 정리
+  useEffect(() => {
+    return () => {
+      if (memoTimeoutRef.current) {
+        clearTimeout(memoTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  // 외부 클릭 시 메뉴 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (moreMenuRef.current && !moreMenuRef.current.contains(event.target as Node)) {
+        setShowMoreMenu(false);
+      }
+    };
+
+    if (showMoreMenu) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [showMoreMenu]);
+
+  // Todo 완료 상태 토글
+  const toggleTodoComplete = async (todo: TodoItem, newStatus: boolean) => {
+    try {
+      const accessToken = tokenManager.getAccessToken();
+      const response = await fetch(`/api/jds/${jdId}/to-do-lists/${todo.checklist_id}`, {
+        method: 'PATCH',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          category: todo.category,
+          title: todo.title,
+          content: todo.content,
+          is_done: newStatus
+        })
+      });
+
+      if (response.ok) {
+        const responseData = await response.json();
+        
+        // 로컬 상태 업데이트 - 실제 응답 구조에 맞춰서 (응답에서는 done 필드 사용)
+        if (jdDetail && responseData.data) {
+          const updatedTodos = jdDetail.toDoLists.map(todoItem =>
+            todoItem.checklist_id === todo.checklist_id 
+              ? { ...todoItem, done: responseData.data.done !== undefined ? responseData.data.done : newStatus }
+              : todoItem
+          );
+          
+          setJdDetail({ ...jdDetail, toDoLists: updatedTodos });
+          
+          // 카테고리별 그룹화도 업데이트
+          const grouped = updatedTodos.reduce((acc: { [key: string]: TodoItem[] }, todo: TodoItem) => {
+            if (!acc[todo.category]) acc[todo.category] = [];
+            acc[todo.category].push(todo);
+            return acc;
+          }, {});
+          setTodosByCategory(grouped);
+        }
+      } else {
+        const errorData = await response.text();
+        console.error('Failed to toggle todo status:', response.status, errorData);
+      }
+    } catch (error) {
+      console.error('Error toggling todo status:', error);
+    }
+  };
+
+  // Todo 수정 함수
+  const editTodo = async (todoId: string, data: { category: string; title: string; content: string }) => {
+    try {
+      // 현재 투두의 완료 상태 찾기
+      const currentTodo = jdDetail?.toDoLists.find(todo => todo.checklist_id.toString() === todoId);
+      const isDone = currentTodo?.done || false;
+
+      const accessToken = tokenManager.getAccessToken();
+      const response = await fetch(`/api/jds/${jdId}/to-do-lists/${todoId}`, {
+        method: 'PATCH',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          ...data,
+          is_done: isDone
+        })
+      });
+
+      if (response.ok) {
+        // 데이터 다시 불러오기
+        const detailResponse = await fetch(`/api/jds/${jdId}`, {
+          headers: {
+            'Authorization': `Bearer ${accessToken}`
+          }
+        });
+
+        if (detailResponse.ok) {
+          const detailData = await detailResponse.json();
+          if (detailData.data) {
+            setJdDetail(detailData.data);
+            
+            // 카테고리별로 투두 그룹화
+            const grouped = detailData.data.toDoLists.reduce((acc: { [key: string]: TodoItem[] }, todo: TodoItem) => {
+              if (!acc[todo.category]) acc[todo.category] = [];
+              acc[todo.category].push(todo);
+              return acc;
+            }, {});
+            setTodosByCategory(grouped);
+          }
+        }
+      } else {
+        console.error('Failed to edit todo');
+        alert('조각 수정에 실패했습니다.');
+      }
+    } catch (error) {
+      console.error('Error editing todo:', error);
+      alert('조각 수정 중 오류가 발생했습니다.');
+    }
+  };
+
+  // Todo 삭제 함수
+  const deleteTodo = async (todoId: string) => {
+    try {
+      const accessToken = tokenManager.getAccessToken();
+      const response = await fetch(`/api/jds/${jdId}/to-do-lists/${todoId}`, {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`
+        }
+      });
+
+      if (response.ok) {
+        // 데이터 다시 불러오기
+        const detailResponse = await fetch(`/api/jds/${jdId}`, {
+          headers: {
+            'Authorization': `Bearer ${accessToken}`
+          }
+        });
+
+        if (detailResponse.ok) {
+          const detailData = await detailResponse.json();
+          if (detailData.data) {
+            setJdDetail(detailData.data);
+            
+            // 카테고리별로 투두 그룹화
+            const grouped = detailData.data.toDoLists.reduce((acc: { [key: string]: TodoItem[] }, todo: TodoItem) => {
+              if (!acc[todo.category]) acc[todo.category] = [];
+              acc[todo.category].push(todo);
+              return acc;
+            }, {});
+            setTodosByCategory(grouped);
+          }
+        }
+      } else {
+        console.error('Failed to delete todo');
+        alert('조각 삭제에 실패했습니다.');
+      }
+    } catch (error) {
+      console.error('Error deleting todo:', error);
+      alert('조각 삭제 중 오류가 발생했습니다.');
+    }
+  };
+
+  // Todo 추가 함수
+  const addTodo = async (data: { category: string; title: string; content: string }) => {
+    try {
+      const accessToken = tokenManager.getAccessToken();
+      const response = await fetch(`/api/jds/${jdId}/to-do-lists`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
+      });
+
+      if (response.ok) {
+        // 데이터 다시 불러오기
+        const detailResponse = await fetch(`/api/jds/${jdId}`, {
+          headers: {
+            'Authorization': `Bearer ${accessToken}`
+          }
+        });
+
+        if (detailResponse.ok) {
+          const detailData = await detailResponse.json();
+          if (detailData.data) {
+            setJdDetail(detailData.data);
+            
+            // 카테고리별로 투두 그룹화
+            const grouped = detailData.data.toDoLists.reduce((acc: { [key: string]: TodoItem[] }, todo: TodoItem) => {
+              if (!acc[todo.category]) acc[todo.category] = [];
+              acc[todo.category].push(todo);
+              return acc;
+            }, {});
+            setTodosByCategory(grouped);
+          }
+        }
+      } else {
+        console.error('Failed to add todo');
+        alert('조각 추가에 실패했습니다.');
+      }
+    } catch (error) {
+      console.error('Error adding todo:', error);
+      alert('조각 추가 중 오류가 발생했습니다.');
+    }
+  };
+
+  // 삭제 핸들러
+  const handleDelete = async () => {
+    try {
+      const accessToken = tokenManager.getAccessToken();
+      const response = await fetch(`/api/jds/${jdId}`, {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`
+        }
+      });
+
+      if (response.ok) {
+        // 삭제 성공 시 홈으로 이동
+        router.push('/');
+      } else {
+        console.error('Failed to delete JD');
+        alert('채용공고 삭제에 실패했습니다.');
+        setIsDeleting(false);
+      }
+    } catch (error) {
+      console.error('Error deleting JD:', error);
+      alert('채용공고 삭제 중 오류가 발생했습니다.');
+      setIsDeleting(false);
+    }
+  };
+
+  const calculateCompletionRate = () => {
+    if (!jdDetail || !jdDetail.toDoLists || jdDetail.toDoLists.length === 0) return { completed: 0, total: 0 };
+    const total = jdDetail.toDoLists.length;
+    const completed = jdDetail.toDoLists.filter(todo => todo.done).length;
+    return { completed, total };
+  };
+
+  if (isLoading) {
+    return (
+      <>
+        <Header backgroundColor="white" showLogout={true} />
+        <main className={styles.main}>
+          <div className={styles.container}>
+            <div style={{ textAlign: 'center', padding: '50px' }}>로딩 중...</div>
+          </div>
+        </main>
+        <Footer />
+      </>
+    );
+  }
+
+  if (!jdDetail) {
+    return (
+      <>
+        <Header backgroundColor="white" showLogout={true} />
+        <main className={styles.main}>
+          <div className={styles.container}>
+            <div style={{ textAlign: 'center', padding: '50px' }}>채용공고를 찾을 수 없습니다.</div>
+          </div>
+        </main>
+        <Footer />
+      </>
+    );
+  }
+
+  const { completed, total } = calculateCompletionRate();
 
   return (
     <>
@@ -48,12 +574,19 @@ export default function JobDetailPage() {
             </div>
 
             <div className={styles.rightSection}>
-              <button className={styles.actionButton}>
+              <button 
+                className={styles.actionButton}
+                onClick={() => {
+                  if (jdDetail.jdUrl) {
+                    window.open(jdDetail.jdUrl, '_blank');
+                  }
+                }}
+              >
                 <span className={styles.actionButtonText}>채용공고 보기</span>
               </button>
 
               <button 
-                className={`${styles.iconButton} ${isBookmarked ? styles.bookmarked : ''}`}
+                className={`${styles.iconButton} ${jdDetail.bookmark ? styles.bookmarked : ''}`}
                 onClick={toggleBookmark}
               >
                 <Image 
@@ -61,18 +594,38 @@ export default function JobDetailPage() {
                   alt="북마크"
                   width={21.33}
                   height={24}
-                  style={{ opacity: isBookmarked ? 1 : 0.7 }}
+                  style={{ opacity: jdDetail.bookmark ? 1 : 0.7 }}
                 />
               </button>
 
-              <button className={styles.iconButton}>
-                <Image 
-                  src={moreIcon}
-                  alt="더보기"
-                  width={21.33}
-                  height={5.33}
-                />
-              </button>
+              <div ref={moreMenuRef} style={{ position: 'relative' }}>
+                <button 
+                  className={styles.iconButton}
+                  onClick={() => setShowMoreMenu(!showMoreMenu)}
+                >
+                  <Image 
+                    src={moreIcon}
+                    alt="더보기"
+                    width={21.33}
+                    height={5.33}
+                  />
+                </button>
+                
+                {/* More menu dropdown */}
+                {showMoreMenu && (
+                  <div className={styles.moreMenu}>
+                    <button 
+                      className={styles.moreMenuItem}
+                      onClick={() => {
+                        setShowMoreMenu(false);
+                        setIsDeleting(true);
+                      }}
+                    >
+                      삭제하기
+                    </button>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
 
@@ -81,25 +634,25 @@ export default function JobDetailPage() {
             <div className={styles.jobDetailsTop}>
               <div className={styles.jobDetailsLeft}>
                 <DDayChip 
-                  alarm="off"
+                  alarm={jdDetail.alarmOn ? "on" : "off"}
                   state="default"
-                  dDay={52}
+                  dDay={calculateDDay(jdDetail.endedAt)}
                 />
                 <div className={styles.modifiedInfo}>
-                  <div className={styles.modifiedText}>3일 전 수정</div>
+                  <div className={styles.modifiedText}>{formatTimeAgo(jdDetail.updatedAt)}</div>
                 </div>
               </div>
               <div className={styles.jobDetailsRight}>
                 <div className={styles.registerInfo}>
                   <div className={styles.registerText}>등록일</div>
                   <div className={styles.separator}>|</div>
-                  <div className={styles.registerText}>25년 5월 24일 목요일</div>
+                  <div className={styles.registerText}>{formatDate(jdDetail.createdAt)}</div>
                 </div>
               </div>
             </div>
             <div className={styles.jobDetailsBottom}>
-              <div className={styles.jobTitle}>풀스택 개발자</div>
-              <div className={styles.companyName}>KT&amp;G</div>
+              <div className={styles.jobTitle}>{jdDetail.title}</div>
+              <div className={styles.companyName}>{jdDetail.companyName}</div>
             </div>
           </div>
 
@@ -109,78 +662,72 @@ export default function JobDetailPage() {
               <div className={styles.progressHeader}>
                 <div className={styles.progressTitle}>완료한 조각</div>
                 <p className={styles.progressCount}>
-                  <span className={styles.progressCountActive}>4</span>
-                  <span className={styles.progressCountTotal}> / 30</span>
+                  <span className={styles.progressCountActive}>{completed}</span>
+                  <span className={styles.progressCountTotal}> / {total}</span>
                 </p>
               </div>
               <ProgressBar
-                total={30}
-                completed={4}
+                total={total}
+                completed={completed}
                 className={styles.progressBarInstance}
               />
             </div>
-            <button className={styles.notificationBtn}>
+            <button 
+              className={`${styles.notificationBtn} ${jdDetail.alarmOn ? styles.alarmOn : ''}`}
+              onClick={toggleAlarm}
+              disabled={isTogglingAlarm}
+            >
               <Image 
                 src={alarmIcon}
                 alt="알림"
                 width={14.2}
                 height={13.1}
               />
-              <div className={styles.notificationBtnText}>알림 신청</div>
+              <div className={styles.notificationBtnText}>
+                {jdDetail.alarmOn ? '알림 중' : '알림 신청'}
+              </div>
             </button>
           </div>
 
           {/* Jogak Categories */}
           <div className={styles.jogakCategories}>
-            <JogakCategory 
-              state="active"
-              title="필요한 경험과 역량"
-              initialItems={[
-                { id: "1", text: "경력 기간 명확화", completed: true },
-                { id: "2", text: "리더 경험 만들기", completed: false },
-                { id: "3", text: "최대 10개 표시입니다.", completed: true },
-                { id: "4", text: "TO DO LIST EXAMPLE", completed: false },
-                { id: "5", text: "투두 리스트 예시", completed: false },
-                { id: "6", text: "투두 리스트 예시", completed: false },
-              ]}
-              checkboxColor="#D9A9F9"
-              className={styles.jogakCategoryInstance}
-              onItemToggle={(itemId) => console.log(`Toggled item: ${itemId}`)}
-            />
-            
-            <JogakCategory 
-              state="active"
-              title="내용 강조 및 재구성"
-              initialItems={[
-                { id: "1", text: "핵심 성과 수치화", completed: false },
-                { id: "2", text: "구체적인 기술 스택 명시", completed: false },
-                { id: "3", text: "프로젝트 임팩트 강조", completed: false },
-                { id: "4", text: "협업 경험 구체화", completed: false },
-                { id: "5", text: "문제 해결 과정 서술", completed: false },
-                { id: "6", text: "성장 과정 스토리텔링", completed: false },
-              ]}
-              checkboxColor="#FFD00E"
-              icon={contentEmphasisIcon}
-              className={styles.jogakCategoryInstance}
-              onItemToggle={(itemId) => console.log(`Toggled emphasis item: ${itemId}`)}
-            />
-            
-            <JogakCategory 
-              state="active"
-              title="취업 일정 및 기타"
-              initialItems={[
-                { id: "1", text: "서류 마감일 확인", completed: false },
-                { id: "2", text: "코딩 테스트 준비", completed: false },
-                { id: "3", text: "면접 예상 질문 정리", completed: false },
-                { id: "4", text: "포트폴리오 업데이트", completed: false },
-                { id: "5", text: "자기소개서 최종 검토", completed: false },
-                { id: "6", text: "레퍼런스 연락처 정리", completed: false },
-              ]}
-              checkboxColor="#3DC3A9"
-              icon={scheduleIcon}
-              className={styles.jogakCategoryInstance}
-              onItemToggle={(itemId) => console.log(`Toggled schedule item: ${itemId}`)}
-            />
+            {CATEGORIES.map(({ value: category }) => {
+              const todos = todosByCategory[category] || [];
+              return (
+              <JogakCategory 
+                key={category}
+                state="active"
+                title={CATEGORY_TITLES[category] || category}
+                initialItems={todos.map(todo => ({
+                  id: todo.checklist_id.toString(),
+                  text: todo.title,
+                  completed: todo.done,
+                  content: todo.content,
+                  fullTodo: todo
+                }))}
+                checkboxColor={CATEGORY_COLORS[category]}
+                icon={CATEGORY_ICONS[category]}
+                className={styles.jogakCategoryInstance}
+                category={category}
+                categories={CATEGORIES}
+                onItemToggle={(itemId) => {
+                  const todo = todos.find(t => t.checklist_id.toString() === itemId);
+                  if (todo) {
+                    toggleTodoComplete(todo, !todo.done);
+                  }
+                }}
+                onItemEdit={(itemId, data) => {
+                  editTodo(itemId, data);
+                }}
+                onItemDelete={(itemId) => {
+                  deleteTodo(itemId);
+                }}
+                onItemAdd={(data) => {
+                  addTodo(data);
+                }}
+              />
+              );
+            })}
           </div>
 
           {/* Memo Box */}
@@ -188,10 +735,44 @@ export default function JobDetailPage() {
             placeholder="해당 조각에 대해 메모해보세요."
             maxLength={1000}
             className={styles.memoBoxInstance}
+            initialValue={jdDetail.memo || ''}
+            onChange={handleMemoChange}
           />
+          {isSavingMemo && (
+            <div style={{ textAlign: 'right', marginTop: '4px', fontSize: '12px', color: '#999' }}>
+              저장 중...
+            </div>
+          )}
         </div>
       </main>
       <Footer />
+      
+      {/* Delete confirmation modal */}
+      {isDeleting && (
+        <div className={styles.modalOverlay}>
+          <div className={styles.modal}>
+            <h3 className={styles.modalTitle}>채용공고 삭제</h3>
+            <p className={styles.modalMessage}>
+              이 채용공고를 삭제하시겠습니까?<br />
+              삭제된 채용공고는 복구할 수 없습니다.
+            </p>
+            <div className={styles.modalButtons}>
+              <button 
+                className={styles.modalCancel}
+                onClick={() => setIsDeleting(false)}
+              >
+                취소
+              </button>
+              <button 
+                className={styles.modalConfirm}
+                onClick={handleDelete}
+              >
+                삭제
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/src/app/job/create/page.module.css
+++ b/src/app/job/create/page.module.css
@@ -222,8 +222,13 @@
   margin-top: 8px;
 }
 
-.completeButton:hover {
+.completeButton:hover:not(:disabled) {
   background-color: var(--primarymain-800);
+}
+
+.completeButton:disabled {
+  background-color: var(--n-400);
+  cursor: not-allowed;
 }
 
 .completeButtonText {

--- a/src/app/job/create/page.tsx
+++ b/src/app/job/create/page.tsx
@@ -7,6 +7,7 @@ import styles from "./page.module.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import arrowBackIcon from "@/assets/images/ic_arrow_back.svg";
+import { tokenManager } from "@/utils/auth";
 
 export default function CreateJobPage() {
   const router = useRouter();
@@ -16,21 +17,66 @@ export default function CreateJobPage() {
   const [deadline, setDeadline] = useState("");
   const [jobDescription, setJobDescription] = useState("");
   const [jobUrl, setJobUrl] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleBack = () => {
     router.back();
   };
 
-  const handleSubmit = () => {
-    // 채용공고 등록 로직
-    console.log({
-      jobTitle,
-      companyName,
-      jobPosition,
-      deadline,
-      jobDescription,
-      jobUrl
-    });
+  const handleSubmit = async () => {
+    // 필수 필드 검증
+    if (!jobTitle.trim()) {
+      alert("채용공고 제목을 입력해주세요.");
+      return;
+    }
+    if (!companyName.trim()) {
+      alert("회사 이름을 입력해주세요.");
+      return;
+    }
+    if (!jobDescription.trim()) {
+      alert("채용공고 내용을 입력해주세요.");
+      return;
+    }
+    if (!deadline) {
+      alert("마감일을 설정해주세요.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const accessToken = tokenManager.getAccessToken();
+      
+      const response = await fetch('/api/jds/create', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${accessToken}`
+        },
+        body: JSON.stringify({
+          title: jobTitle,
+          companyName: companyName,
+          job: jobPosition || "채용",  // 직무명 필수 - 기본값 제공
+          content: jobDescription,
+          link: jobUrl,  // jdUrl로 변환은 API route에서 처리
+          endDate: deadline
+        })
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        alert("채용공고가 성공적으로 등록되었습니다.\nAI가 분석하여 맞춤형 투두리스트를 생성했습니다.");
+        // JD 상세 페이지로 이동
+        router.push(`/job/${data.data.jdId}`);
+      } else {
+        alert(data.message || "채용공고 등록에 실패했습니다.");
+      }
+    } catch (error) {
+      console.error('JD submission error:', error);
+      alert("채용공고 등록 중 오류가 발생했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -121,8 +167,14 @@ export default function CreateJobPage() {
             </div>
 
             {/* 완료하기 버튼 */}
-            <button className={styles.completeButton} onClick={handleSubmit}>
-              <span className={styles.completeButtonText}>조각 생성하기</span>
+            <button 
+              className={styles.completeButton} 
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+            >
+              <span className={styles.completeButtonText}>
+                {isSubmitting ? 'AI가 분석 중...' : '조각 생성하기'}
+              </span>
             </button>
           </div>
         </div>

--- a/src/app/main/page.module.css
+++ b/src/app/main/page.module.css
@@ -39,3 +39,42 @@
     flex-direction: column;
   }
 }
+
+/* Skeleton loading styles */
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--n-200) 25%,
+    var(--n-300) 50%,
+    var(--n-200) 75%
+  );
+  background-size: 200% 100%;
+  animation: loading 1.5s infinite;
+}
+
+@keyframes loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.resumeLoading {
+  width: 100%;
+  max-width: 1560px;
+}
+
+.jobLoading {
+  display: flex;
+  gap: 24px;
+  width: 100%;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 768px) {
+  .jobLoading {
+    flex-direction: column;
+  }
+}

--- a/src/app/resume/create/page.module.css
+++ b/src/app/resume/create/page.module.css
@@ -254,3 +254,49 @@
   top: 50%;
   transform: translate(-50%, -50%);
 }
+
+/* Loading spinner styles */
+.loadingContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 360px;
+  background-color: var(--n-100);
+  border-radius: 10px;
+  gap: 16px;
+}
+
+.fullLoadingContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 500px;
+  gap: 16px;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid var(--n-300);
+  border-top-color: var(--primaryjogak-1);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.loadingText {
+  color: var(--n-600);
+  font-size: 14px;
+  font-weight: 400;
+  margin: 0;
+}

--- a/src/app/resume/create/page.tsx
+++ b/src/app/resume/create/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import styles from "./page.module.css";
@@ -22,14 +22,7 @@ export default function CreateResumePage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  // resumeId가 있으면 기존 이력서 불러오기
-  useEffect(() => {
-    if (resumeId) {
-      fetchResume();
-    }
-  }, [resumeId]);
-
-  const fetchResume = async () => {
+  const fetchResume = useCallback(async () => {
     setIsLoading(true);
     try {
       const accessToken = tokenManager.getAccessToken();
@@ -51,7 +44,14 @@ export default function CreateResumePage() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [resumeId]);
+
+  // resumeId가 있으면 기존 이력서 불러오기
+  useEffect(() => {
+    if (resumeId) {
+      fetchResume();
+    }
+  }, [resumeId, fetchResume]);
 
   const handleBack = () => {
     router.back();

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -7,14 +7,26 @@ interface ButtonProps {
   children: React.ReactNode;
   onClick?: () => void;
   className?: string;
+  type?: "button" | "submit" | "reset";
+  disabled?: boolean;
 }
 
-export function Button({ variant = "primary", children, onClick, className = "" }: ButtonProps) {
+export function Button({ 
+  variant = "primary", 
+  children, 
+  onClick, 
+  className = "", 
+  type = "button",
+  disabled = false
+}: ButtonProps) {
+  const isDisabled = disabled || variant === "disabled";
+  
   return (
     <button 
       className={`${styles.btn} ${styles[variant]} ${className}`}
       onClick={onClick}
-      disabled={variant === "disabled"}
+      disabled={isDisabled}
+      type={type}
     >
       <div className={styles.textWrapper}>{children}</div>
     </button>

--- a/src/components/DDayChip.tsx
+++ b/src/components/DDayChip.tsx
@@ -9,7 +9,6 @@ interface Props {
 }
 
 export function DDayChip({ 
-  alarm = "off", 
   state = "default", 
   className = "",
   dDay = 52 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,10 +4,48 @@ import Image from "next/image";
 import logo from "@/assets/images/logo.svg";
 import emailIcon from "@/assets/images/ico_email.svg";
 import styles from "./Footer.module.css";
+import { tokenManager } from "@/utils/auth";
 
 export default function Footer() {
   const scrollToTop = () => {
     window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  const handleWithdrawal = async () => {
+    const confirmed = confirm(
+      "정말로 탈퇴하시겠습니까?\n\n탈퇴 시 모든 데이터가 삭제되며 복구할 수 없습니다."
+    );
+
+    if (!confirmed) return;
+
+    try {
+      const accessToken = tokenManager.getAccessToken();
+      
+      if (!accessToken) {
+        alert("로그인이 필요합니다.");
+        return;
+      }
+
+      const response = await fetch('/api/member/withdrawal', {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+        },
+      });
+
+      if (response.ok) {
+        alert("탈퇴가 완료되었습니다.");
+        // 토큰 삭제하고 홈으로 이동
+        tokenManager.removeAccessToken();
+        window.location.href = '/';
+      } else {
+        const errorData = await response.json();
+        alert(`탈퇴에 실패했습니다: ${errorData.message || '알 수 없는 오류'}`);
+      }
+    } catch (error) {
+      console.error('Withdrawal error:', error);
+      alert("탈퇴 중 오류가 발생했습니다.");
+    }
   };
 
   return (
@@ -47,7 +85,7 @@ export default function Footer() {
           </div>
 
           {/* Withdraw link */}
-          <a href="#" className={styles.withdrawLink}>탈퇴하기</a>
+          <button onClick={handleWithdrawal} className={styles.withdrawLink}>탈퇴하기</button>
         </div>
 
         {/* Scroll to top button */}

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -21,6 +21,11 @@
   display: flex;
   align-items: center;
   cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.logo:hover {
+  opacity: 0.8;
 }
 
 .logo img {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,12 +24,14 @@ export default function Header({ backgroundColor = "transparent", showLogout = f
     setIsLoginModalOpen(false);
   };
 
-  const handleLogoutClick = async () => {
-    try {
-      await logout();
-    } catch (error) {
+  const handleLogoutClick = () => {
+    // 즉시 UI 업데이트를 위해 홈으로 이동
+    window.location.href = '/';
+    
+    // 백그라운드에서 로그아웃 처리
+    logout().catch(error => {
       console.error('Logout failed:', error);
-    }
+    });
   };
 
   return (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import styles from "./Header.module.css";
 import logo from "@/assets/images/logo.svg";
 import logoutIcon from "@/assets/images/ic_logout.svg";
@@ -37,7 +38,7 @@ export default function Header({ backgroundColor = "transparent", showLogout = f
   return (
     <>
       <header className={`${styles.header} ${backgroundColor === "white" ? styles.whiteBackground : ""}`}>
-        <div className={styles.logo}>
+        <Link href="/" className={styles.logo}>
           <Image 
             src={logo} 
             alt="조각조각 로고" 
@@ -45,7 +46,7 @@ export default function Header({ backgroundColor = "transparent", showLogout = f
             height={25.11}
             priority
           />
-        </div>
+        </Link>
         {showLogout ? (
           <button className={styles.logoutButton} onClick={handleLogoutClick}>
             <Image 

--- a/src/components/JobList.tsx
+++ b/src/components/JobList.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useReducer } from "react";
-import Image from "next/image";
 import styles from "./JobList.module.css";
 import { ProgressBar } from "./ProgressBar";
 
@@ -17,7 +16,12 @@ interface Props {
   onClick?: () => void;
 }
 
-function reducer(state: any, action: any) {
+interface State {
+  state: string;
+  originalState: string;
+}
+
+function reducer(state: State, action: string): State {
   switch (action) {
     case "mouse_enter":
       return {

--- a/src/components/JogakCategory.tsx
+++ b/src/components/JogakCategory.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import { StaticImageData } from "next/image";
 import styles from "./JogakCategory.module.css";
@@ -11,6 +11,18 @@ interface JogakItem {
   id: string;
   text: string;
   completed: boolean;
+  content?: string;
+  fullTodo?: {
+    checklist_id: number;
+    category: string;
+    title: string;
+    content: string;
+    memo: string;
+    jdId: number;
+    createdAt: string;
+    updatedAt: string;
+    done: boolean;
+  };
 }
 
 interface Props {
@@ -19,8 +31,13 @@ interface Props {
   title?: string;
   initialItems?: JogakItem[];
   onItemToggle?: (itemId: string) => void;
+  onItemEdit?: (itemId: string, data: { category: string; title: string; content: string }) => void;
+  onItemDelete?: (itemId: string) => void;
+  onItemAdd?: (data: { category: string; title: string; content: string }) => void;
   checkboxColor?: string;
   icon?: StaticImageData;
+  category?: string;
+  categories?: { value: string; label: string }[];
 }
 
 export function JogakCategory({
@@ -34,11 +51,21 @@ export function JogakCategory({
     { id: "4", text: "TO DO LIST EXAMPLE", completed: false },
   ],
   onItemToggle,
+  onItemEdit,
+  onItemDelete,
+  onItemAdd,
   checkboxColor = "#D9A9F9",
-  icon = experienceIcon
+  icon = experienceIcon,
+  category,
+  categories = []
 }: Props) {
   const [items, setItems] = useState<JogakItem[]>(initialItems);
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // initialItems가 변경될 때 내부 state 업데이트
+  useEffect(() => {
+    setItems(initialItems);
+  }, [initialItems]);
 
   const handleItemToggle = (itemId: string) => {
     setItems(prevItems => 
@@ -129,6 +156,11 @@ export function JogakCategory({
         icon={icon}
         checkboxColor={checkboxColor}
         onItemToggle={handleItemToggle}
+        onItemEdit={onItemEdit}
+        onItemDelete={onItemDelete}
+        onItemAdd={onItemAdd}
+        category={category}
+        categories={categories}
       />
     </div>
   );

--- a/src/components/JogakDetailModal.tsx
+++ b/src/components/JogakDetailModal.tsx
@@ -23,7 +23,7 @@ export function JogakDetailModal({
   onClick,
   checkboxColor = "#D9A9F9",
   completedAt,
-  description = "JD에서 요구한 1~3년 경력에 부합하도록, 'Moneed' 프로젝트와 'SnapX' 인턴십을 포함한 총 경력기간을 명확히 표기.",
+  description,
   onEdit,
   onDelete,
   onMemoChange

--- a/src/components/MemoBox.tsx
+++ b/src/components/MemoBox.tsx
@@ -7,19 +7,28 @@ interface Props {
   maxLength?: number;
   placeholder?: string;
   className?: string;
+  initialValue?: string;
+  onChange?: (value: string) => void;
 }
 
 export function MemoBox({ 
   maxLength = 1000, 
   placeholder = "해당 조각에 대해 메모해보세요.",
-  className = ""
+  className = "",
+  initialValue = "",
+  onChange
 }: Props) {
-  const [text, setText] = useState("");
+  const [text, setText] = useState(initialValue);
+  
+  React.useEffect(() => {
+    setText(initialValue);
+  }, [initialValue]);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newText = e.target.value;
     if (newText.length <= maxLength) {
       setText(newText);
+      onChange?.(newText);
     }
   };
 

--- a/src/components/ResumeRegistration.module.css
+++ b/src/components/ResumeRegistration.module.css
@@ -42,6 +42,30 @@
   left: auto !important;
 }
 
+.resumeInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.resumeTitle {
+  color: var(--n-800);
+  font-family: var(--headline-1-bold-font-family);
+  font-size: var(--headline-1-bold-font-size);
+  font-style: var(--headline-1-bold-font-style);
+  font-weight: var(--headline-1-bold-font-weight);
+  letter-spacing: var(--headline-1-bold-letter-spacing);
+  line-height: var(--headline-1-bold-line-height);
+}
+
+.resumeUpdated {
+  color: var(--n-500);
+  font-family: var(--body-2-regular-font-family);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+}
+
 /* Responsive adjustments */
 @media (max-width: 1600px) {
   .resumeDesktop {
@@ -98,5 +122,20 @@
     right: auto !important;
     left: auto !important;
     transform: none !important;
+  }
+
+  .resumeInfo {
+    flex: 1;
+  }
+
+  .resumeTitle {
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 700;
+  }
+
+  .resumeUpdated {
+    font-size: 12px;
+    line-height: 16px;
   }
 }

--- a/src/components/ResumeRegistration.tsx
+++ b/src/components/ResumeRegistration.tsx
@@ -6,12 +6,60 @@ import styles from "./ResumeRegistration.module.css";
 import cautionIcon from "@/assets/images/ic_caution.svg";
 import { Button } from "./Button";
 
-export function ResumeRegistration() {
+interface ResumeRegistrationProps {
+  hasResume?: boolean;
+  resumeId?: number;
+  resumeTitle?: string;
+  resumeUpdatedAt?: string;
+}
+
+export function ResumeRegistration({ hasResume = false, resumeId, resumeTitle, resumeUpdatedAt }: ResumeRegistrationProps) {
   const router = useRouter();
 
-  const handleResumeRegister = () => {
-    router.push("/resume/create");
+  const handleResumeClick = () => {
+    if (hasResume && resumeId) {
+      router.push(`/resume/create?id=${resumeId}`);
+    } else {
+      router.push("/resume/create");
+    }
   };
+
+  const formatTimeAgo = (dateString?: string) => {
+    if (!dateString) return '';
+    
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+    
+    if (diffInSeconds < 60) {
+      return `${diffInSeconds}초 전 수정`;
+    } else if (diffInSeconds < 3600) {
+      const minutes = Math.floor(diffInSeconds / 60);
+      return `${minutes}분 전 수정`;
+    } else if (diffInSeconds < 86400) {
+      const hours = Math.floor(diffInSeconds / 3600);
+      return `${hours}시간 전 수정`;
+    } else {
+      const days = Math.floor(diffInSeconds / 86400);
+      return `${days}일 전 수정`;
+    }
+  };
+
+  if (hasResume) {
+    return (
+      <div className={styles.resumeDesktop}>
+        <div className={styles.resumeInfo}>
+          <div className={styles.resumeTitle}>{resumeTitle || '나의 이력서'}</div>
+          <div className={styles.resumeUpdated}>{formatTimeAgo(resumeUpdatedAt)}</div>
+        </div>
+        <div className={styles.btnInstance}>
+          <Button variant="primary" onClick={handleResumeClick}>
+            이력서 수정
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.resumeDesktop}>
@@ -26,7 +74,7 @@ export function ResumeRegistration() {
         <div className={styles.div}>이력서 등록이 필요해요.</div>
       </div>
       <div className={styles.btnInstance}>
-        <Button variant="primary" onClick={handleResumeRegister}>
+        <Button variant="primary" onClick={handleResumeClick}>
           이력서 등록
         </Button>
       </div>

--- a/src/components/TodoEditModal.module.css
+++ b/src/components/TodoEditModal.module.css
@@ -1,0 +1,115 @@
+.backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
+.modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  z-index: 1001;
+  width: 90%;
+  max-width: 500px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modalContent {
+  padding: 0;
+}
+
+.modalHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 24px 0 24px;
+  border-bottom: 1px solid #E5E7EB;
+  margin-bottom: 24px;
+}
+
+.modalTitle {
+  font-size: 18px;
+  font-weight: 600;
+  color: #111827;
+  margin: 0;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.closeButton:hover {
+  background-color: #F3F4F6;
+}
+
+.form {
+  padding: 0 24px 24px 24px;
+}
+
+.formGroup {
+  margin-bottom: 20px;
+}
+
+.label {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 8px;
+}
+
+.select,
+.input,
+.textarea {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #D1D5DB;
+  border-radius: 8px;
+  font-size: 14px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  box-sizing: border-box;
+}
+
+.select:focus,
+.input:focus,
+.textarea:focus {
+  outline: none;
+  border-color: #8B5CF6;
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 120px;
+  font-family: inherit;
+}
+
+.charCount {
+  font-size: 12px;
+  color: #6B7280;
+  text-align: right;
+  margin-top: 4px;
+}
+
+.modalFooter {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 32px;
+  padding-top: 20px;
+  border-top: 1px solid #E5E7EB;
+}

--- a/src/components/TodoEditModal.tsx
+++ b/src/components/TodoEditModal.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import styles from "./TodoEditModal.module.css";
+import { Button } from "./Button";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: { category: string; title: string; content: string }) => void;
+  initialData?: {
+    category: string;
+    title: string;
+    content: string;
+  };
+  categories: { value: string; label: string }[];
+}
+
+export function TodoEditModal({
+  isOpen,
+  onClose,
+  onSave,
+  initialData,
+  categories
+}: Props) {
+  const [formData, setFormData] = useState({
+    category: "",
+    title: "",
+    content: ""
+  });
+
+  useEffect(() => {
+    if (initialData) {
+      setFormData(initialData);
+    } else {
+      setFormData({
+        category: categories[0]?.value || "",
+        title: "",
+        content: ""
+      });
+    }
+  }, [initialData, categories, isOpen]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (formData.title.trim() && formData.content.trim()) {
+      onSave(formData);
+      onClose();
+    }
+  };
+
+  const handleInputChange = (field: string, value: string) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value
+    }));
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Modal backdrop */}
+      <div className={styles.backdrop} onClick={onClose} />
+      
+      {/* Modal content */}
+      <div className={styles.modal}>
+        <div className={styles.modalContent}>
+          <div className={styles.modalHeader}>
+            <h3 className={styles.modalTitle}>
+              {initialData ? "조각 수정" : "조각 추가"}
+            </h3>
+            <button className={styles.closeButton} onClick={onClose}>
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+                <path d="M18 6L6 18M6 6L18 18" stroke="#94A2B3" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            </button>
+          </div>
+
+          <form onSubmit={handleSubmit} className={styles.form}>
+            <div className={styles.formGroup}>
+              <label className={styles.label}>카테고리</label>
+              <select
+                value={formData.category}
+                onChange={(e) => handleInputChange("category", e.target.value)}
+                className={styles.select}
+                required
+              >
+                {categories.map((category) => (
+                  <option key={category.value} value={category.value}>
+                    {category.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className={styles.formGroup}>
+              <label className={styles.label}>제목</label>
+              <input
+                type="text"
+                value={formData.title}
+                onChange={(e) => handleInputChange("title", e.target.value)}
+                className={styles.input}
+                placeholder="제목을 입력하세요 (최대 50자)"
+                maxLength={50}
+                required
+              />
+              <div className={styles.charCount}>
+                {formData.title.length}/50
+              </div>
+            </div>
+
+            <div className={styles.formGroup}>
+              <label className={styles.label}>내용</label>
+              <textarea
+                value={formData.content}
+                onChange={(e) => handleInputChange("content", e.target.value)}
+                className={styles.textarea}
+                placeholder="내용을 입력하세요 (최소 30자)"
+                minLength={30}
+                rows={5}
+                required
+              />
+              <div className={styles.charCount}>
+                {formData.content.length}자 {formData.content.length < 30 && `(최소 30자 필요)`}
+              </div>
+            </div>
+
+            <div className={styles.modalFooter}>
+              <Button
+                variant="tertiary"
+                onClick={onClose}
+                type="button"
+              >
+                취소
+              </Button>
+              <Button
+                variant="primary"
+                type="submit"
+                disabled={!formData.title.trim() || !formData.content.trim() || formData.content.length < 30}
+              >
+                {initialData ? "수정" : "추가"}
+              </Button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -99,6 +99,9 @@ export async function fetchWithAuth(url: string, options: RequestInit = {}): Pro
 
 // 로그아웃 함수
 export async function logout() {
+  // 즉시 토큰 제거
+  tokenManager.removeAccessToken();
+  
   try {
     const refreshToken = await tokenManager.getRefreshToken();
     
@@ -114,8 +117,5 @@ export async function logout() {
     }
   } catch (error) {
     console.error('Logout error:', error);
-  } finally {
-    tokenManager.removeAccessToken();
-    window.location.href = '/';
   }
 }


### PR DESCRIPTION
## Summary
투두 리스트 완전한 CRUD 기능 구현 및 회원 탈퇴 기능 추가

## 주요 변경사항

### 투두 리스트 CRUD 기능
- 투두 체크박스 상태 업데이트 API 연동
- 투두 생성/수정/삭제 API 라우트 구현  
- 투두 수정/추가 모달 컴포넌트 개발
- JogakModal과 JogakCategory에 CRUD 기능 통합

### 회원 관리 기능
- 회원 탈퇴 API 연동 및 UI 구현
- Footer 탈퇴하기 버튼 기능 연결

### 코드 품질 개선
- Button 컴포넌트에 type, disabled props 추가
- TypeScript 타입 오류 수정
- ESLint 경고 해결

## Test plan
- 투두 항목 체크/언체크 동작 확인
- 투두 수정/삭제/추가 기능 테스트
- 회원 탈퇴 기능 동작 확인
- 카테고리별 투두 표시 순서 확인