### PR TITLE
feat: JogakCategory 아이템 클릭 시 모달 자동 확장 기능

### DIFF
--- a/src/components/JogakCategory.tsx
+++ b/src/components/JogakCategory.tsx
@@ -61,6 +61,7 @@ export function JogakCategory({
 }: Props) {
   const [items, setItems] = useState<JogakItem[]>(initialItems);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
 
   // initialItems가 변경될 때 내부 state 업데이트
   useEffect(() => {
@@ -76,12 +77,16 @@ export function JogakCategory({
     onItemToggle?.(itemId);
   };
 
-  const handleModalOpen = () => {
+  const handleModalOpen = (itemId?: string) => {
+    if (itemId) {
+      setSelectedItemId(itemId);
+    }
     setIsModalOpen(true);
   };
 
   const handleModalClose = () => {
     setIsModalOpen(false);
+    setSelectedItemId(null);
   };
 
   return (
@@ -120,7 +125,7 @@ export function JogakCategory({
           viewBox="0 0 24 24" 
           fill="none" 
           className={styles.chevron}
-          onClick={handleModalOpen}
+          onClick={() => handleModalOpen()}
           style={{ cursor: 'pointer' }}
         >
           <path d="M9 18L15 12L9 6" stroke="#94A2B3" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
@@ -129,19 +134,37 @@ export function JogakCategory({
       
       <div className={`${styles.itemList} ${styles[`state-${state}`]}`}>
         {items.map((item) => (
-          <div key={item.id} className={styles.jogakItem} onClick={() => handleItemToggle(item.id)}>
+          <div key={item.id} className={styles.jogakItem}>
             <div className={styles.itemContent}>
               <div 
                 className={`${styles.checkbox} ${item.completed ? styles.checked : ''}`}
                 style={item.completed ? { borderColor: checkboxColor } : {}}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleItemToggle(item.id);
+                }}
               >
                 {item.completed && (
                   <div className={styles.checkSquare} style={{ backgroundColor: checkboxColor }} />
                 )}
               </div>
-              <div className={styles.itemText}>{item.text}</div>
+              <div 
+                className={styles.itemText} 
+                onClick={() => handleModalOpen(item.id)}
+                style={{ cursor: 'pointer' }}
+              >
+                {item.text}
+              </div>
             </div>
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" className={styles.itemChevron}>
+            <svg 
+              width="24" 
+              height="24" 
+              viewBox="0 0 24 24" 
+              fill="none" 
+              className={styles.itemChevron}
+              onClick={() => handleModalOpen(item.id)}
+              style={{ cursor: 'pointer' }}
+            >
               <path d="M9 18L15 12L9 6" stroke="#B0BDCB" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
           </div>
@@ -161,6 +184,7 @@ export function JogakCategory({
         onItemAdd={onItemAdd}
         category={category}
         categories={categories}
+        selectedItemId={selectedItemId}
       />
     </div>
   );

--- a/src/components/JogakDetailModal.tsx
+++ b/src/components/JogakDetailModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styles from "./JogakDetailModal.module.css";
 
 interface Props {
@@ -30,6 +30,11 @@ export function JogakDetailModal({
 }: Props) {
   const [isExpanded, setIsExpanded] = useState(state === "active" || state === "active-memo");
   const [memo, setMemo] = useState("");
+
+  // state prop이 변경될 때 isExpanded 업데이트
+  useEffect(() => {
+    setIsExpanded(state === "active" || state === "active-memo");
+  }, [state]);
 
   const handleToggleExpand = () => {
     if (state !== "add-custom") {

--- a/src/components/JogakModal.tsx
+++ b/src/components/JogakModal.tsx
@@ -39,6 +39,7 @@ interface Props {
   onItemAdd?: (data: { category: string; title: string; content: string }) => void;
   category?: string;
   categories?: { value: string; label: string }[];
+  selectedItemId?: string | null;
 }
 
 export function JogakModal({
@@ -53,10 +54,22 @@ export function JogakModal({
   onItemDelete,
   onItemAdd,
   category,
-  categories = []
+  categories = [],
+  selectedItemId
 }: Props) {
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<JogakItem | null>(null);
+  const [openDetailItemId, setOpenDetailItemId] = useState<string | null>(null);
+
+  // selectedItemId가 변경되면 해당 아이템의 상세 모달 열기
+  React.useEffect(() => {
+    if (selectedItemId && isOpen) {
+      const item = items.find(item => item.id === selectedItemId);
+      if (item) {
+        setOpenDetailItemId(selectedItemId);
+      }
+    }
+  }, [selectedItemId, isOpen, items]);
 
   const handleEditClick = (item: JogakItem) => {
     setEditingItem(item);
@@ -124,7 +137,7 @@ export function JogakModal({
               {items.map((item) => (
                 <JogakDetailModal
                   key={item.id}
-                  state={item.completed ? "done" : "default"}
+                  state={item.completed ? "done" : (openDetailItemId === item.id ? "active" : "default")}
                   text={item.text}
                   description={item.content}
                   onClick={() => onItemToggle?.(item.id)}


### PR DESCRIPTION
## Summary
- JogakCategory의 아이템 텍스트 또는 Chevron 클릭 시 모달이 열리면서 해당 아이템이 자동으로 확장되어 표시
- 체크박스는 체크 on/off 기능만 수행

## Changes
### JogakCategory 컴포넌트
- 아이템별 클릭 이벤트 분리 (체크박스 vs 텍스트/Chevron)
- 선택된 아이템 ID를 JogakModal에 전달

### JogakModal 컴포넌트
- selectedItemId prop 추가
- 선택된 아이템 자동 확장 로직 구현

### JogakDetailModal 컴포넌트
- state prop 변경 시 확장 상태 자동 업데이트