### PR TITLE
feat: 채용공고 더보기 메뉴에 지원 완료 옵션 추가

### DIFF
--- a/src/components/JobList.module.css
+++ b/src/components/JobList.module.css
@@ -385,3 +385,58 @@
 .state-dayover .registerDate {
   color: var(--n-500);
 }
+
+/* More menu styles */
+.moreButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.moreButton:hover {
+  background-color: var(--n-100);
+}
+
+.moreMenu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  background-color: var(--n-0);
+  border: 1px solid var(--n-200);
+  border-radius: 8px;
+  box-shadow: 0px 4px 16px 0px rgba(0, 0, 0, 0.12);
+  overflow: hidden;
+  z-index: 100;
+  min-width: 120px;
+}
+
+.moreMenuItem {
+  display: block;
+  width: 100%;
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-family: var(--body-2-normal-medium-font-family);
+  font-size: var(--body-2-normal-medium-font-size);
+  font-weight: var(--body-2-normal-medium-font-weight);
+  line-height: var(--body-2-normal-medium-line-height);
+  color: var(--n-800);
+  transition: background-color 0.2s ease;
+}
+
+.moreMenuItem:hover {
+  background-color: var(--n-100);
+}
+
+.moreMenuItem + .moreMenuItem {
+  border-top: 1px solid var(--n-200);
+}

--- a/src/components/JobList.tsx
+++ b/src/components/JobList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useReducer } from "react";
+import React, { useReducer, useState, useRef, useEffect } from "react";
 import styles from "./JobList.module.css";
 import { ProgressBar } from "./ProgressBar";
 
@@ -14,6 +14,8 @@ interface Props {
   totalCount?: string | number;
   dDay?: number;
   onClick?: () => void;
+  onApplyComplete?: () => void;
+  onDelete?: () => void;
 }
 
 interface State {
@@ -47,14 +49,35 @@ export function JobList({
   totalCount = "30",
   dDay = 52,
   onClick,
+  onApplyComplete,
+  onDelete,
 }: Props) {
   const [state, dispatch] = useReducer(reducer, {
     state: stateProp,
     originalState: stateProp,
   });
+  const [showMoreMenu, setShowMoreMenu] = useState(false);
+  const moreMenuRef = useRef<HTMLDivElement>(null);
 
   const totalCountNum = typeof totalCount === 'string' ? parseInt(totalCount) : totalCount;
   const completedCountNum = parseInt(completedCount);
+
+  // 외부 클릭 시 메뉴 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (moreMenuRef.current && !moreMenuRef.current.contains(event.target as Node)) {
+        setShowMoreMenu(false);
+      }
+    };
+
+    if (showMoreMenu) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [showMoreMenu]);
 
   return (
     <div
@@ -86,12 +109,46 @@ export function JobList({
                 </div>
               )}
             </div>
-            <div className={styles.iconWrapper}>
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                <path d="M12 8C13.1046 8 14 7.10457 14 6C14 4.89543 13.1046 4 12 4C10.8954 4 10 4.89543 10 6C10 7.10457 10.8954 8 12 8Z" fill="#94A2B3"/>
-                <path d="M12 14C13.1046 14 14 13.1046 14 12C14 10.8954 13.1046 10 12 10C10.8954 10 10 10.8954 10 12C10 13.1046 10.8954 14 12 14Z" fill="#94A2B3"/>
-                <path d="M12 20C13.1046 20 14 19.1046 14 18C14 16.8954 13.1046 16 12 16C10.8954 16 10 16.8954 10 18C10 19.1046 10.8954 20 12 20Z" fill="#94A2B3"/>
-              </svg>
+            <div className={styles.iconWrapper} ref={moreMenuRef}>
+              <button 
+                className={styles.moreButton}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowMoreMenu(!showMoreMenu);
+                }}
+              >
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+                  <path d="M12 8C13.1046 8 14 7.10457 14 6C14 4.89543 13.1046 4 12 4C10.8954 4 10 4.89543 10 6C10 7.10457 10.8954 8 12 8Z" fill="#94A2B3"/>
+                  <path d="M12 14C13.1046 14 14 13.1046 14 12C14 10.8954 13.1046 10 12 10C10.8954 10 10 10.8954 10 12C10 13.1046 10.8954 14 12 14Z" fill="#94A2B3"/>
+                  <path d="M12 20C13.1046 20 14 19.1046 14 18C14 16.8954 13.1046 16 12 16C10.8954 16 10 16.8954 10 18C10 19.1046 10.8954 20 12 20Z" fill="#94A2B3"/>
+                </svg>
+              </button>
+              
+              {/* More menu dropdown */}
+              {showMoreMenu && (
+                <div className={styles.moreMenu}>
+                  <button 
+                    className={styles.moreMenuItem}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowMoreMenu(false);
+                      onApplyComplete?.();
+                    }}
+                  >
+                    지원 완료
+                  </button>
+                  <button 
+                    className={styles.moreMenuItem}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowMoreMenu(false);
+                      onDelete?.();
+                    }}
+                  >
+                    삭제하기
+                  </button>
+                </div>
+              )}
             </div>
           </div>
           <div className={styles.frame3}>


### PR DESCRIPTION
## Summary
- 채용공고 상세 페이지와 리스트의 더보기 메뉴에 '지원 완료' 옵션 추가
- alert 대신 Snackbar 컴포넌트 사용

## Changes
### 채용공고 상세 페이지
- 더보기 메뉴에 '지원 완료' 버튼 추가
- 지원 완료 API 호출 구현
- Snackbar로 성공/실패 메시지 표시

### JobList 컴포넌트
- 더보기 메뉴 기능 구현
- '지원 완료', '삭제하기' 버튼 추가
- 외부 클릭 시 메뉴 닫기

### 스타일
- 더보기 메뉴 드롭다운 스타일 추가
- hover 효과 및 구분선 스타일