### PR TITLE
feat: 투두리스트 상세 내용 한 번에 하나만 표시

### DIFF
--- a/src/components/JogakDetailModal.tsx
+++ b/src/components/JogakDetailModal.tsx
@@ -14,6 +14,8 @@ interface Props {
   onEdit?: () => void;
   onDelete?: () => void;
   onMemoChange?: (memo: string) => void;
+  onToggleExpand?: () => void;
+  isExpanded?: boolean;
 }
 
 export function JogakDetailModal({
@@ -26,19 +28,29 @@ export function JogakDetailModal({
   description,
   onEdit,
   onDelete,
-  onMemoChange
+  onMemoChange,
+  onToggleExpand,
+  isExpanded: isExpandedProp
 }: Props) {
-  const [isExpanded, setIsExpanded] = useState(state === "active" || state === "active-memo");
+  const [isExpanded, setIsExpanded] = useState(false);
   const [memo, setMemo] = useState("");
 
-  // state prop이 변경될 때 isExpanded 업데이트
+  // props로 받은 isExpanded가 있으면 사용, 없으면 state에 따라 결정
   useEffect(() => {
-    setIsExpanded(state === "active" || state === "active-memo");
-  }, [state]);
+    if (isExpandedProp !== undefined) {
+      setIsExpanded(isExpandedProp);
+    } else {
+      setIsExpanded(state === "active" || state === "active-memo");
+    }
+  }, [state, isExpandedProp]);
 
   const handleToggleExpand = () => {
     if (state !== "add-custom") {
-      setIsExpanded(!isExpanded);
+      if (onToggleExpand) {
+        onToggleExpand();
+      } else {
+        setIsExpanded(!isExpanded);
+      }
     }
   };
 

--- a/src/components/JogakModal.tsx
+++ b/src/components/JogakModal.tsx
@@ -59,17 +59,26 @@ export function JogakModal({
 }: Props) {
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<JogakItem | null>(null);
-  const [openDetailItemId, setOpenDetailItemId] = useState<string | null>(null);
+  const [expandedItemId, setExpandedItemId] = useState<string | null>(null);
 
-  // selectedItemId가 변경되면 해당 아이템의 상세 모달 열기
+  // selectedItemId가 변경되면 해당 아이템 확장
   React.useEffect(() => {
     if (selectedItemId && isOpen) {
-      const item = items.find(item => item.id === selectedItemId);
-      if (item) {
-        setOpenDetailItemId(selectedItemId);
-      }
+      setExpandedItemId(selectedItemId);
     }
-  }, [selectedItemId, isOpen, items]);
+  }, [selectedItemId, isOpen]);
+
+  // 모달이 닫힐 때 확장 상태 초기화
+  React.useEffect(() => {
+    if (!isOpen) {
+      setExpandedItemId(null);
+    }
+  }, [isOpen]);
+
+  const handleItemToggleExpand = (itemId: string) => {
+    // 같은 아이템을 클릭하면 닫기, 다른 아이템을 클릭하면 해당 아이템만 열기
+    setExpandedItemId(expandedItemId === itemId ? null : itemId);
+  };
 
   const handleEditClick = (item: JogakItem) => {
     setEditingItem(item);
@@ -137,7 +146,7 @@ export function JogakModal({
               {items.map((item) => (
                 <JogakDetailModal
                   key={item.id}
-                  state={item.completed ? "done" : (openDetailItemId === item.id ? "active" : "default")}
+                  state={item.completed ? "done" : "default"}
                   text={item.text}
                   description={item.content}
                   onClick={() => onItemToggle?.(item.id)}
@@ -145,6 +154,8 @@ export function JogakModal({
                   completedAt={item.completed ? "24.12.15 14:30:00" : undefined}
                   onEdit={() => handleEditClick(item)}
                   onDelete={() => handleDeleteClick(item)}
+                  isExpanded={expandedItemId === item.id}
+                  onToggleExpand={() => handleItemToggleExpand(item.id)}
                 />
               ))}
               <JogakDetailModal state="add-custom" onClick={handleAddClick} />


### PR DESCRIPTION
## Summary
- 투두리스트(조각) 모달에서 한 번에 하나의 아이템만 상세 내용이 보이도록 변경
- 다른 아이템을 클릭하면 이전에 열려있던 아이템이 자동으로 닫힘

## Changes
### JogakModal
- expandedItemId 상태로 중앙 관리
- 한 번에 하나의 아이템만 확장 가능하도록 로직 구현

### JogakDetailModal  
- isExpanded, onToggleExpand props 추가
- 부모 컴포넌트에서 확장 상태 제어 가능하도록 변경

## 동작
- 아이템 A 상세 내용을 보다가 아이템 B를 클릭하면 A는 닫히고 B만 열림
- 같은 아이템을 다시 클릭하면 닫힘