### PR TITLE
fix: 대시보드 스켈레톤 로딩 너비를 이력서 카드와 일치시킴

### DIFF
--- a/src/app/dashboard/page.module.css
+++ b/src/app/dashboard/page.module.css
@@ -63,8 +63,9 @@
 }
 
 .resumeLoading {
-  width: 100%;
+  width: calc(100% - 40px);
   max-width: 1560px;
+  margin: 0 20px;
 }
 
 .jobLoading {
@@ -77,5 +78,10 @@
 @media (max-width: 768px) {
   .jobSection {
     margin: 0 16px;
+  }
+  
+  .resumeLoading {
+    width: calc(100% - 32px);
+    margin: 12px 16px 0;
   }
 }


### PR DESCRIPTION
## Summary
- 스켈레톤 로딩 상태에서 이력서 카드와 동일한 너비 및 여백 적용
- PC와 모바일 모두 일관된 레이아웃 유지