### PR TITLE
채용공고 생성 응답 필드명 수정 (jdId → jd_id)

### DIFF
--- a/src/app/job/create/page.tsx
+++ b/src/app/job/create/page.tsx
@@ -64,7 +64,7 @@ export default function CreateJobPage() {
       const data = await response.json();
 
       if (response.ok) {
-        setNextJdId(data.data.jdId);
+        setNextJdId(data.data.jd_id);
         setIsComplete(true);
         // LoadingModal의 onCompleteAnimationEnd에서 페이지 이동 처리
       } else {


### PR DESCRIPTION
## Summary
- 서버 응답의 필드명이 `jd_id`로 변경됨에 따라 프론트엔드 코드 수정
- 채용공고 생성 후 리다이렉트가 정상 동작하도록 수정