### PR TITLE
feat: 채용공고 목록 페이지네이션 구현

### DIFF
--- a/src/app/dashboard/page.module.css
+++ b/src/app/dashboard/page.module.css
@@ -86,3 +86,48 @@
     margin: 12px 16px 0;
   }
 }
+
+/* 페이지네이션 스타일 */
+.pagination {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  margin-top: 32px;
+  padding: 0 4px;
+}
+
+.paginationButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 16px 40px;
+  background-color: var(--primaryjogak-1);
+  border: none;
+  border-radius: 8px;
+  font-family: var(--headline-2-bold-font-family);
+  font-weight: var(--headline-2-bold-font-weight);
+  color: var(--n-0);
+  font-size: var(--headline-2-bold-font-size);
+  letter-spacing: var(--headline-2-bold-letter-spacing);
+  line-height: var(--headline-2-bold-line-height);
+  white-space: nowrap;
+  font-style: var(--headline-2-bold-font-style);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  overflow: hidden;
+}
+
+.paginationButton:hover {
+  background-color: #2e7ae6;
+  transform: translateY(-1px);
+}
+
+.paginationButton:active {
+  transform: translateY(0);
+}
+
+.nextButton {
+  margin-left: auto;
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -44,6 +44,8 @@ export default function DashboardPage() {
   const [showNoResumeSnackbar, setShowNoResumeSnackbar] = useState(false);
   const [deletingJobId, setDeletingJobId] = useState<number | null>(null);
   const [snackbar, setSnackbar] = useState({ isOpen: false, message: '', type: 'success' as 'success' | 'error' | 'info' });
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 12;
 
   useEffect(() => {
     // 로그인 상태 확인
@@ -219,24 +221,64 @@ export default function DashboardPage() {
           />
           
           <div className={styles.jobSection}>
-            <JobAdd hasResume={!!resume} onNoResumeClick={handleNoResumeClick} />
+            {currentPage === 1 && (
+              <JobAdd hasResume={!!resume} onNoResumeClick={handleNoResumeClick} />
+            )}
             
             {jds.length > 0 && (
-              jds.map((jd) => (
-                <JobList
-                  key={jd.jd_id}
-                  title={jd.title}
-                  company={jd.companyName}
-                  registerDate={formatDate(jd.createdAt)}
-                  state="default"
-                  completedCount={String(jd.completed_pieces)}
-                  totalCount={String(jd.total_pieces)}
-                  dDay={calculateDDay(jd.endedAt)}
-                  onClick={() => handleJobClick(jd.jd_id)}
-                  onApplyComplete={() => handleApplyComplete(jd.jd_id)}
-                  onDelete={() => setDeletingJobId(jd.jd_id)}
-                />
-              ))
+              <>
+                {(() => {
+                  const startIndex = currentPage === 1 ? 0 : (currentPage - 1) * itemsPerPage - 1;
+                  const endIndex = currentPage === 1 ? itemsPerPage - 1 : startIndex + itemsPerPage;
+                  
+                  return jds
+                    .slice(startIndex, endIndex)
+                    .map((jd) => (
+                    <JobList
+                      key={jd.jd_id}
+                      title={jd.title}
+                      company={jd.companyName}
+                      registerDate={formatDate(jd.createdAt)}
+                      state="default"
+                      completedCount={String(jd.completed_pieces)}
+                      totalCount={String(jd.total_pieces)}
+                      dDay={calculateDDay(jd.endedAt)}
+                      onClick={() => handleJobClick(jd.jd_id)}
+                      onApplyComplete={() => handleApplyComplete(jd.jd_id)}
+                      onDelete={() => setDeletingJobId(jd.jd_id)}
+                    />
+                  ));
+                })()}
+                
+                {/* 페이지네이션 버튼 */}
+                {(() => {
+                  const totalItems = jds.length + 1; // +1 for JobAdd button on first page
+                  const hasNextPage = currentPage === 1 
+                    ? totalItems > itemsPerPage - 1
+                    : jds.length > (currentPage - 1) * itemsPerPage - 1;
+                    
+                  return (totalItems > itemsPerPage || currentPage > 1) && (
+                  <div className={styles.pagination}>
+                    {currentPage > 1 && (
+                      <button
+                        className={styles.paginationButton}
+                        onClick={() => setCurrentPage(currentPage - 1)}
+                      >
+                        이전
+                      </button>
+                    )}
+                    {hasNextPage && (
+                      <button
+                        className={`${styles.paginationButton} ${styles.nextButton}`}
+                        onClick={() => setCurrentPage(currentPage + 1)}
+                      >
+                        다음
+                      </button>
+                    )}
+                  </div>
+                  );
+                })()}
+              </>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- 한 페이지당 최대 12개 표시 (첫 페이지: 추가 버튼 1개 + 채용공고 11개)
- 2페이지부터는 채용공고 12개만 표시
- 이전/다음 버튼으로 페이지 이동