### PR TITLE
feat: 채용공고 목록 정렬 기능 구현

### DIFF
--- a/src/app/dashboard/page.module.css
+++ b/src/app/dashboard/page.module.css
@@ -131,3 +131,57 @@
 .nextButton {
   margin-left: auto;
 }
+
+/* 정렬 드롭다운 스타일 */
+.sortContainer {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  margin: 0 20px 16px 20px;
+}
+
+.sortDropdown {
+  position: relative;
+}
+
+.sortSelect {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-color: #ffffff;
+  border: 1px solid var(--n-300);
+  border-radius: 8px;
+  padding: 12px 40px 12px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+  cursor: pointer;
+  min-width: 120px;
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  background-size: 16px;
+}
+
+.sortSelect:hover {
+  border-color: var(--n-400);
+  background-color: var(--n-50);
+}
+
+.sortSelect:focus {
+  outline: none;
+  border-color: var(--primaryjogak-1);
+  box-shadow: 0 0 0 3px rgba(52, 131, 250, 0.1);
+}
+
+@media (max-width: 768px) {
+  .sortContainer {
+    margin: 0 16px 12px 16px;
+  }
+  
+  .sortSelect {
+    padding: 10px 32px 10px 12px;
+    font-size: 13px;
+    min-width: 100px;
+  }
+}


### PR DESCRIPTION
## Summary
- 대시보드 우측 상단에 정렬 드롭다운 추가
- 최신순/오래된 순 정렬 옵션 제공
- 백엔드 API와 연동하여 실시간 정렬 기능 구현